### PR TITLE
Add calibrators, expand blend sweep, and migrate CSV helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy",
     "typer",
     "joblib",
+    "scikit-learn",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/acs/io/csv_utils.py
+++ b/src/acs/io/csv_utils.py
@@ -1,0 +1,65 @@
+"""Utilities for discovering and reading CSV files.
+
+Extracted from legacy `acs_panel_unified_3.py` so the project no longer
+relies on that monolithic script. Provides helpers to search for CSV files
+by keyword or code, pick the best candidate and read it with encoding
+fallbacks.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import List, Optional
+
+import pandas as pd
+
+PREFER_KEYWORDS = ("acs_prob", "prob", "acs")
+
+
+def list_csvs(root: str, code: Optional[str] = None) -> List[str]:
+    """Recursively list CSV files under *root*.
+
+    If *code* is provided, only files containing the code are returned.
+    Temporary files prefixed with ``~`` are ignored.
+    """
+    if code and str(code).strip():
+        pattern = os.path.join(root, "**", f"*{code}*.csv")
+    else:
+        pattern = os.path.join(root, "**", "*acs*.csv")
+    files = glob.glob(pattern, recursive=True)
+    return [f for f in files if os.path.isfile(f) and not os.path.basename(f).startswith("~")]
+
+
+def _score_csv_path(path: str) -> tuple[int, int, float]:
+    base = os.path.basename(path).lower()
+    kw_hits = sum(1 for kw in PREFER_KEYWORDS if kw in base)
+    depth = -len(os.path.normpath(path).split(os.sep))
+    try:
+        mtime = os.path.getmtime(path)
+    except Exception:
+        mtime = 0.0
+    return kw_hits, depth, mtime
+
+
+def pick_best_csv(files: List[str]) -> Optional[str]:
+    """Pick the best CSV from *files* using keyword hits, path depth and mtime."""
+    if not files:
+        return None
+    return sorted(files, key=_score_csv_path, reverse=True)[0]
+
+
+def read_csv_smart(path: str) -> pd.DataFrame:
+    """Read CSV with a set of common encodings.
+
+    Tries UTF-8 variants first, then falls back to GBK/ANSI to gracefully
+    handle files exported from Windows tools.
+    """
+    last_err: Exception | None = None
+    for enc in ("utf-8-sig", "utf-8", "gbk", "ansi"):
+        try:
+            return pd.read_csv(path, encoding=enc)
+        except Exception as e:  # pragma: no cover - only executed on failure
+            last_err = e
+    assert last_err is not None
+    raise last_err

--- a/src/acs/io/fetchers.py
+++ b/src/acs/io/fetchers.py
@@ -1,9 +1,12 @@
+import random
 import re
+import time
 import pandas as pd
-from typing import Optional
+from typing import Optional, List
 from ..registry import REGISTRY
 from ..utils.legacy import load_legacy
 from ..utils.compat import call_legacy
+
 
 def _norm_cn_symbol(sym: str) -> str:
     """Extract 6-digit code from inputs like '000001.SZ', 'sz000001', '000001'."""
@@ -29,36 +32,74 @@ def _ak_to_std_cols(df: pd.DataFrame) -> pd.DataFrame:
     keep = [c for c in ['open','high','low','close','volume'] if c in df.columns]
     return df[keep]
 
-def _fetch_via_akshare(symbol: str, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+def _fetch_via_akshare(
+    symbol: str,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    *,
+    chunk_days: int = 120,
+    max_retries: int = 4,
+    base_sleep: float = 0.8,
+    debug_log: Optional[List[str]] = None,
+) -> pd.DataFrame:
+    """Fetch data via AkShare with chunking and retry."""
     try:
         import akshare as ak
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         raise RuntimeError(f"需要 akshare 才能直接取数，请安装: pip install akshare; 原因: {e}")
+
     out_frames = []
     cur = start
+    code = _norm_cn_symbol(symbol)
     while cur <= end:
-        ce = min(cur + pd.Timedelta(days=119), end)
+        ce = min(cur + pd.Timedelta(days=chunk_days - 1), end)
         s8, e8 = cur.strftime('%Y%m%d'), ce.strftime('%Y%m%d')
-        code = _norm_cn_symbol(symbol)
-        df = ak.stock_zh_a_hist(symbol=code, period='daily', start_date=s8, end_date=e8, adjust='qfq')
-        if df is None or df.empty:
-            # 再试一次不复权
-            df = ak.stock_zh_a_hist(symbol=code, period='daily', start_date=s8, end_date=e8, adjust='')
-        if df is None or df.empty:
-            raise RuntimeError(f"AkShare 返回空: {code} {s8}-{e8}")
-        out_frames.append(_ak_to_std_cols(df))
+        last_err: Exception | None = None
+        for k in range(1, max_retries + 1):
+            try:
+                df = ak.stock_zh_a_hist(symbol=code, period='daily', start_date=s8, end_date=e8, adjust='qfq')
+                if df is None or df.empty:
+                    df = ak.stock_zh_a_hist(symbol=code, period='daily', start_date=s8, end_date=e8, adjust='')
+                if df is None or df.empty:
+                    raise RuntimeError(f"AkShare 返回空: {code} {s8}-{e8}")
+                out_frames.append(_ak_to_std_cols(df))
+                if debug_log is not None:
+                    debug_log.append(f"[fetch] ok {s8}-{e8} rows={len(df)} try#{k}")
+                break
+            except Exception as e1:
+                last_err = e1
+                msg = str(e1)
+                net_terms = ["10054", "Connection aborted", "Read timed out", "Max retries exceeded"]
+                if any(t in msg for t in net_terms) and k < max_retries:
+                    sleep = base_sleep * (2 ** (k - 1)) * (1 + 0.2 * random.random())
+                    if debug_log is not None:
+                        debug_log.append(f"[fetch] retry {s8}-{e8} try#{k} sleep={sleep:.2f}s err={msg[:100]}")
+                    time.sleep(sleep)
+                    continue
+                raise
+        else:
+            raise RuntimeError(f"网络多次失败：{s8}-{e8}｜最后错误：{last_err}")
         cur = ce + pd.Timedelta(days=1)
+
     res = pd.concat(out_frames).sort_index()
-    # to numeric
     for c in res.columns:
         res[c] = pd.to_numeric(res[c], errors='coerce')
     return res
 
 @REGISTRY.register("fetcher", "akshare")
-def fetch_daily(symbol: str, start: Optional[str]=None, end: Optional[str]=None) -> pd.DataFrame:
+def fetch_daily(
+    symbol: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    *,
+    chunk_days: int = 120,
+    max_retries: int = 4,
+    base_sleep: float = 0.8,
+    debug_log: Optional[List[str]] = None,
+) -> pd.DataFrame:
     """Fetch daily OHLCV with robust symbol normalization.
     - First try user's legacy fetcher
-    - If it raises/returns空, fallback to direct AkShare
+    - If it raises/returns空, fallback to direct AkShare with retry
     """
     legacy = load_legacy()
     s = pd.to_datetime(start) if start is not None else None
@@ -66,7 +107,7 @@ def fetch_daily(symbol: str, start: Optional[str]=None, end: Optional[str]=None)
     if e is None:
         e = pd.Timestamp.today().normalize()
     if s is None:
-        s = e - pd.Timedelta(days=365*5)
+        s = e - pd.Timedelta(days=365 * 5)
 
     # 1) try legacy
     if legacy and hasattr(legacy, "fetch_daily"):
@@ -75,11 +116,18 @@ def fetch_daily(symbol: str, start: Optional[str]=None, end: Optional[str]=None)
             if df is not None and not df.empty:
                 df.columns = [c.lower() for c in df.columns]
                 return df
-        except Exception as ex:
-            # fallthrough to direct akshare
+        except Exception:
             pass
 
     # 2) fallback: direct AkShare
-    df = _fetch_via_akshare(symbol, s, e)
+    df = _fetch_via_akshare(
+        symbol,
+        s,
+        e,
+        chunk_days=chunk_days,
+        max_retries=max_retries,
+        base_sleep=base_sleep,
+        debug_log=debug_log,
+    )
     df.columns = [c.lower() for c in df.columns]
     return df

--- a/src/acs/model/calibration.py
+++ b/src/acs/model/calibration.py
@@ -3,6 +3,47 @@ from typing import Dict, Any
 from ..registry import REGISTRY
 from ..utils.legacy import load_legacy
 from ..utils.compat import call_legacy
+from sklearn.linear_model import LogisticRegression
+from sklearn.isotonic import IsotonicRegression
+
+@REGISTRY.register("calibrator", "platt")
+def platt(prob: pd.Series, y: pd.Series, cfg: Dict[str, Any]) -> pd.Series:
+    """Pure Platt scaling using logistic regression.
+
+    Drops NaNs for fitting to avoid sklearn errors, then writes calibrated
+    values back to the original index. Falls back to identity if fitting fails.
+    """
+    out = prob.copy()
+    mask = prob.notna() & y.notna()
+    if mask.sum() == 0:
+        return out.clip(0, 1)
+    try:
+        lr = LogisticRegression(**cfg)
+        lr.fit(prob[mask].values.reshape(-1, 1), y[mask].values)
+        out.loc[mask] = lr.predict_proba(prob[mask].values.reshape(-1, 1))[:, 1]
+        return out.clip(0, 1)
+    except Exception:
+        return out.clip(0, 1)
+
+
+@REGISTRY.register("calibrator", "isotonic")
+def isotonic(prob: pd.Series, y: pd.Series, cfg: Dict[str, Any]) -> pd.Series:
+    """Pure isotonic regression calibrator.
+
+    Drops NaNs for fitting to avoid sklearn errors, then writes calibrated
+    values back to the original index. Falls back to identity if fitting fails.
+    """
+    out = prob.copy()
+    mask = prob.notna() & y.notna()
+    if mask.sum() == 0:
+        return out.clip(0, 1)
+    try:
+        iso = IsotonicRegression(out_of_bounds="clip", **cfg)
+        iso.fit(prob[mask].values, y[mask].values)
+        out.loc[mask] = iso.predict(prob[mask].values)
+        return out.clip(0, 1)
+    except Exception:
+        return out.clip(0, 1)
 
 @REGISTRY.register("calibrator","legacy_platt_isotonic")
 def legacy_platt_isotonic(prob: pd.Series, y: pd.Series, cfg: Dict[str, Any]) -> pd.Series:

--- a/sweep_blend.py
+++ b/sweep_blend.py
@@ -22,7 +22,8 @@ def main(cfg_path: str):
 
     # ========= 1) 融合参数 sweep =========
     print("Running blend sweep…")
-    grid = list(itertools.product([False, True], [0.0, 0.1, 0.2, 0.3, 0.4]))
+    w_range = [round(i * 0.05, 2) for i in range(21)]
+    grid = list(itertools.product([False, True], w_range))
     results = []
     for invert_sup, w_unsup in grid:
         c = deepcopy(base)


### PR DESCRIPTION
## Summary
- add standalone Platt and isotonic calibration options and register them
- extend blend sweep to search unsupervised weight up to 1.0 in 0.05 steps
- migrate CSV search/reading helpers and implement a retrying AkShare fetcher

## Testing
- `python - <<'PY'
import sys, os, pandas as pd
sys.path.append('src')
from acs.io import csv_utils
import tempfile

with tempfile.TemporaryDirectory() as d:
    p1 = os.path.join(d, 'sample_acs_prob.csv')
    pd.DataFrame({'a':[1,2]}).to_csv(p1, index=False)
    files = csv_utils.list_csvs(d)
    print('files', [os.path.basename(f) for f in files])
    best = csv_utils.pick_best_csv(files)
    print('best', os.path.basename(best))
    df = csv_utils.read_csv_smart(best)
    print('read', df.to_dict('list'))
PY`
- `python - <<'PY'
import sys
sys.path.append('src')
from acs.io.fetchers import fetch_daily

try:
    df = fetch_daily('000001.SZ', start='2024-01-01', end='2024-01-10')
    print(df.head().to_dict('records'))
except Exception as e:
    print('fetch failed:', e)
PY`
- `python - <<'PY'
import sys
sys.path.append('src')
from acs.registry import REGISTRY
from acs import discover
import pandas as pd, numpy as np

discover()
prob = pd.Series(np.linspace(0,1,10))
y = pd.Series([0,1]*5)
for name in ['platt','isotonic','legacy_platt_isotonic']:
    fn = REGISTRY.get('calibrator', name)
    out = fn(prob, y, {})
    print(name, out.head().tolist())
PY`


------
https://chatgpt.com/codex/tasks/task_b_6899e176ea3c833396b7af942cafa8b1